### PR TITLE
Add support for MacOS X (10.10)

### DIFF
--- a/git-mvn-wrapper.sh
+++ b/git-mvn-wrapper.sh
@@ -11,13 +11,44 @@
 
 set -e
 
-if ! echo "$*" | grep -qE '(^|\s)-O(\s|$)'; then
+# Replacement for GNU xargs -r
+maybe_xargs() {
+  _in=
+  while read _line; do
+    _in="${_line} ${_in}"
+  done
+  if [ -n "${_in}" ]; then
+    "$@" ${_in}
+  fi
+}
+
+find_module() {
+  NDIR=$(dirname "$1")
+  DIR="."
+  while [ ! "$NDIR" = "$DIR" ] && [ ! -f "$NDIR/pom.xml" ]; do
+    DIR="$NDIR"
+    NDIR=$(dirname "$DIR")
+  done
+  echo "$NDIR"
+}
+
+real_args=
+optimize=
+while [ $# -gt 0 ]; do
+  if [ "$1" = "-O" ]; then
+    optimize=true
+  else
+    real_args="${real_args} \"$1\""
+  fi
+  shift
+done
+
+if [ -z "${optimize}" ]; then
   # Regular Maven execution requested. Pass on all arguments as-is.
-  mvn "$@"
+  eval mvn ${real_args}
 else
   # Optimized Maven execution requested. Drop the custom flag.
-  ARGS=$(echo "$*" | sed -r 's,(^|\s)-O(\s|$),\1\2,')
-  set -- $ARGS
+  set -- ${real_args}
 
   if ! git rev-parse --is-inside-git-dir > /dev/null 2>&1; then
     # This is not a Git repository; can't optimize the build.
@@ -29,18 +60,12 @@ else
     # module to which the file belongs. Remove duplicates and join the
     # remaining module directory names with commas. Lastly, instruct Maven to
     # only build modified modules and their dependents.
-    git ls-files --modified \
-      | xargs -I{} sh -c '
-          NDIR=$(dirname "{}")
-          DIR="."
-          while [ ! "$NDIR" = "$DIR" ] && [ ! -f "$NDIR/pom.xml" ]; do
-            DIR="$NDIR"
-            NDIR=$(dirname "$DIR")
-          done
-          echo "$NDIR"
-      ' \
+    for _file in `git ls-files --modified`; do
+      find_module "${_file}"
+    done \
       | sort -u \
-      | sed -z 's/\n/,/g' \
-      | xargs -r mvn $@ -amd -pl
+      | xargs echo \
+      | tr ' ' ',' \
+      | eval maybe_xargs mvn $@ -amd -pl
   fi
 fi

--- a/git-mvn-wrapper.sh
+++ b/git-mvn-wrapper.sh
@@ -15,6 +15,9 @@ set -e
 maybe_xargs() {
   _in=
   while read _line; do
+    if [ -z "${_line}" ]; then
+      continue
+    fi
     _in="${_line} ${_in}"
   done
   if [ -n "${_in}" ]; then

--- a/git-mvn-wrapper.sh
+++ b/git-mvn-wrapper.sh
@@ -63,7 +63,7 @@ else
     # module to which the file belongs. Remove duplicates and join the
     # remaining module directory names with commas. Lastly, instruct Maven to
     # only build modified modules and their dependents.
-    for _file in `git ls-files --modified`; do
+    git ls-files --modified | while read _file; do
       find_module "${_file}"
     done \
       | sort -u \

--- a/git-mvn-wrapper.sh
+++ b/git-mvn-wrapper.sh
@@ -69,6 +69,6 @@ else
       | sort -u \
       | xargs echo \
       | tr ' ' ',' \
-      | eval maybe_xargs mvn $@ -amd -pl
+      | maybe_xargs mvn "$@" -amd -pl
   fi
 fi


### PR DESCRIPTION
- xargs -r: GNU extension, reimplemented using a shell function
- sed -z: GNU extension, reimplemented by piping through echo (removing
  the newlines) and tr (adding the ',')
- xargs -I{}: reimplemented using a for-loop, to avoid hitting
  the 255-byte limitation for eacho argument of xargs(1)

While there: replace the grep-parsing by a filtering for-loop, which
as a side-effect fixes command line arguments with quotes due to the use
of eval.
